### PR TITLE
Add functionality to deploy caasp4 on openstack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,3 +104,22 @@ ingress:
 .PHONY: ingress-forward
 ingress-forward:
 	scripts/ingress-forward.sh
+
+.PHONY: deps-caasp4os
+deps-caasp4os: deps
+	scripts/docker_skuba.sh
+
+.PHONY: caasp4os-deploy
+caasp4os-deploy:
+	scripts/caasp4os_deploy.sh
+
+.PHONY: caasp-prepare
+caasp-prepare:
+	scripts/caasp_prepare.sh
+
+.PHONY: all-caasp4os
+all-caasp4os: deps-caasp4os caasp4os-deploy caasp-prepare gen-config chart setup scf login
+
+.PHONY: clean-caasp4os
+clean-caasp4os:
+	scripts/caasp4os_destroy.sh

--- a/caasp4/docker/skuba/Dockerfile
+++ b/caasp4/docker/skuba/Dockerfile
@@ -1,0 +1,15 @@
+FROM registry.opensuse.org/opensuse/leap/15.1/images/totest/containers/opensuse/leap:15.1
+
+ARG VERSION
+ARG REPO_ENV
+ARG REPO
+
+RUN zypper ar --no-gpgcheck "${REPO}" "skuba-${REPO_ENV}" && \
+    zypper ar --no-gpgcheck "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/SUSE:CA.repo" && \
+    zypper ref && \
+    zypper in --auto-agree-with-licenses --no-confirm "skuba-${VERSION}" terraform ca-certificates-suse openssh && \
+    zypper clean -a
+
+VOLUME ["/app"]
+
+WORKDIR /app

--- a/caasp4/docker/skuba/Makefile
+++ b/caasp4/docker/skuba/Makefile
@@ -1,0 +1,12 @@
+devel:
+	./build.sh devel http://download.suse.de/ibs/Devel:/CaaSP:/4.0/SLE_15_SP1/
+
+.PHONY: staging
+staging:
+	./build.sh staging http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/staging/
+
+product:
+	./build.sh product http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/standard/
+
+update:
+	./build.sh update http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40:/Update/standard/

--- a/caasp4/docker/skuba/build.sh
+++ b/caasp4/docker/skuba/build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+REPO_ENV="$1"
+REPO="$2"
+VERSION=
+
+retrieve_version() {
+  local output=$(docker run --rm -ti registry.suse.com/suse/sle15 sh -c "zypper rr -a && zypper ar -G $REPO skuba-$REPO_ENV > /dev/null 2>&1 && zypper --no-color --no-gpg-checks info -r skuba-$REPO_ENV skuba")
+
+  if [[ $? -eq 0 ]]; then
+    # 0.5.0-1.2 ^M$
+    VERSION="$(echo -n "$output" | grep --color=never "Version" | sed 's/V.*: //' | tr -d ' \t\n\r')"
+
+    echo ">>> INFO: skuba version found, $VERSION"
+    return
+  fi
+
+  if [[ -z $VERSION ]]; then
+    echo ">>> ERROR: no skuba version found" && exit 1
+  fi
+}
+
+build_container() {
+  # local IMAGE_NAME="skuba/$REPO_ENV-$VERSION"
+  local IMAGE_NAME="skuba/$REPO_ENV"
+
+  if [[ "$(docker images -q skuba/$CAASP_VER 2> /dev/null)" == "" ]]; then
+      echo ">>> INFO: Building $IMAGE_NAME"
+      docker build --no-cache -t "$IMAGE_NAME" \
+             --build-arg VERSION="$VERSION" \
+             --build-arg REPO_ENV="$REPO_ENV" \
+             --build-arg REPO="$REPO" .
+  fi
+}
+
+retrieve_version
+build_container

--- a/caasp4/terraform-os/lbaas-cap.tf
+++ b/caasp4/terraform-os/lbaas-cap.tf
@@ -1,0 +1,31 @@
+resource "openstack_lb_listener_v2" "uaa_listener" {
+  protocol        = "TCP"
+  protocol_port   = "2793"
+  loadbalancer_id = "${openstack_lb_loadbalancer_v2.lb.id}"
+  name            = "${var.stack_name}-uaa-listener"
+}
+
+resource "openstack_lb_pool_v2" "uaa_pool" {
+  name        = "${var.stack_name}-uaa-pool"
+  protocol    = "TCP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = "${openstack_lb_listener_v2.uaa_listener.id}"
+}
+
+resource "openstack_lb_member_v2" "uaa_member" {
+  count         = "${var.workers}"
+  pool_id       = "${openstack_lb_pool_v2.uaa_pool.id}"
+  address       = "${element(openstack_compute_instance_v2.worker.*.access_ip_v4, count.index)}"
+  subnet_id     = "${openstack_networking_subnet_v2.subnet.id}"
+  protocol_port = 2793
+}
+
+resource "openstack_lb_monitor_v2" "uaa_monitor" {
+  pool_id        = "${openstack_lb_pool_v2.uaa_pool.id}"
+  type           = "TCP"
+  url_path       = "/healthz"
+  expected_codes = 200
+  delay          = 10
+  timeout        = 5
+  max_retries    = 3
+}

--- a/caasp4/terraform-os/security-groups-cap.tf
+++ b/caasp4/terraform-os/security-groups-cap.tf
@@ -1,0 +1,46 @@
+resource "openstack_compute_secgroup_v2" "secgroup_cap" {
+  name        = "caasp-cap-${var.stack_name}"
+  description = "CAP security group"
+
+  rule {
+    from_port   = 80 
+    to_port     = 80 
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 443 
+    to_port     = 443
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 2222 
+    to_port     = 2222
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 2793
+    to_port     = 2793
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 4443 
+    to_port     = 4443 
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 20000 
+    to_port     = 20008 
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+}

--- a/caasp4/terraform-os/storage-instance.tf
+++ b/caasp4/terraform-os/storage-instance.tf
@@ -1,0 +1,258 @@
+# NFS storage addon receipt for caasp4 terraform based deployments
+#
+# Copy this file to ~/caasp/deployment/openstack/ on your caasp management
+# system before running 
+#   `terraform apply` 
+# to deploy the cluster. It then will add an additional opensuse leap15.1
+# machine to the caasp4 network running a nfs server, sharing 
+# /srv/nfs/kubedata with the proper permissions.
+# This nfs share can then be consumed by nfs provisoener within caasp4.
+#
+# Warning: This receipt consumes caasp4 templates and will not work outside
+# the caasp4 terraform environment.
+
+
+locals {
+  image = "openSUSE-Leap-15.1-JeOS.x86_64-OpenStack-Cloud"
+  flavor = "c4.large"
+  user = "opensuse"
+  nfs_config = "rw,sync,no_subtree_check,no_root_squash,no_all_squash,insecure"
+  nfs_share = "/srv/nfs/kubedata"
+  storage_packages = [
+    "kernel-default",
+    "-kernel-default-base",
+    "nfs-client",
+    "nfs-kernel-server",
+    "yast2-nfs-server"
+  ]
+}
+
+data "template_file" "storage_repositories" {
+  template = "${file("cloud-init/repository.tpl")}"
+  count    = "${length(var.repositories)}"
+
+  vars {
+    repository_url  = "${element(values(var.repositories), count.index)}"
+    repository_name = "${element(keys(var.repositories), count.index)}"
+  }
+}
+
+data "template_file" "storage_register_scc" {
+  template = "${file("cloud-init/register-scc.tpl")}"
+  count    = "${var.caasp_registry_code == "" ? 0 : 1}"
+
+  vars {
+    caasp_registry_code = "${var.caasp_registry_code}"
+  }
+}
+
+data "template_file" "storage_register_rmt" {
+  template = "${file("cloud-init/register-rmt.tpl")}"
+  count    = "${var.rmt_server_name == "" ? 0 : 1}"
+
+  vars {
+    rmt_server_name = "${var.rmt_server_name}"
+  }
+}
+
+data "template_file" "storage_commands" {
+  template = "${file("cloud-init/commands.tpl")}"
+
+  vars {
+    packages = "${join(", ", local.storage_packages)}"
+  }
+}
+
+data "template_file" "storage-cloud-init" {
+  template = "${file("cloud-init/common.tpl")}"
+
+  vars {
+    authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
+    repositories    = ""
+    register_scc    = ""
+    register_rmt    = ""
+    commands        = "${join("\n", data.template_file.storage_commands.*.rendered)}"
+    username        = "${local.user}" 
+    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
+  }
+}
+
+resource "openstack_compute_instance_v2" "storage" {
+  count      = 1
+  name       = "caasp-storage-${var.stack_name}-${count.index}"
+  image_name = "${local.image}"
+
+  depends_on = [
+    "openstack_networking_network_v2.network",
+    "openstack_networking_subnet_v2.subnet",
+  ]
+
+  flavor_name = "${local.flavor}"
+
+  network {
+    name = "${var.internal_net}"
+  }
+
+  security_groups = [
+    "${openstack_compute_secgroup_v2.secgroup_base.name}",
+    "${openstack_compute_secgroup_v2.secgroup_storage.name}",
+  ]
+
+  user_data = "${data.template_file.storage-cloud-init.rendered}"
+}
+
+resource "openstack_networking_floatingip_v2" "storage_ext" {
+  count = 1
+  pool  = "${var.external_net}"
+}
+
+resource "openstack_compute_floatingip_associate_v2" "storage_ext_ip" {
+  count       = 1 
+  floating_ip = "${element(openstack_networking_floatingip_v2.storage_ext.*.address, count.index)}"
+  instance_id = "${element(openstack_compute_instance_v2.storage.*.id, count.index)}"
+}
+
+resource "null_resource" "storage_wait_cloudinit" {
+  depends_on = ["openstack_compute_instance_v2.storage"]
+  count      = 1
+
+  connection {
+    host = "${element(openstack_compute_floatingip_associate_v2.storage_ext_ip.*.floating_ip, count.index)}"
+    user = "${local.user}"
+    type = "ssh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait > /dev/null",
+    ]
+  }
+}
+
+resource "null_resource" "storage_reboot" {
+  depends_on = ["null_resource.storage_config"]
+  count      = 1
+
+  provisioner "local-exec" {
+    environment = {
+      user = "${local.user}"
+      host = "${element(openstack_compute_floatingip_associate_v2.storage_ext_ip.*.floating_ip, count.index)}"
+    }
+
+    command = <<EOT
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo reboot || :
+# wait for ssh ready after reboot
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -oConnectionAttempts=60 $user@$host /usr/bin/true
+EOT
+  }
+}
+
+resource "null_resource" "storage_config" {
+  depends_on = ["null_resource.storage_wait_cloudinit"]
+  count      = 1
+
+  connection {
+    host = "${element(openstack_compute_floatingip_associate_v2.storage_ext_ip.*.floating_ip, count.index)}"
+    user = "${local.user}"
+    type = "ssh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /srv/nfs/kubedata",
+      "sudo chmod 777 /srv/nfs/kubedata",
+      "sudo chown nobody: /srv/nfs/kubedata",
+      "sudo yast nfs_server add mountpoint=\"${local.nfs_share}\" hosts=\"*\" options=\"${local.nfs_config}\"",
+      "sudo yast nfs_server set enablev4=\"Yes\" domain=\"localdomain\" security=\"No\"",
+      "sudo systemctl enable nfs-server",
+    ]
+  }
+}
+
+resource "openstack_compute_secgroup_v2" "secgroup_storage" {
+  name        = "caasp-storage-${var.stack_name}"
+  description = "Basic security group"
+
+  rule {
+    from_port   = -1
+    to_port     = -1
+    ip_protocol = "icmp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 22
+    to_port     = 22
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 111
+    to_port     = 111
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 2049
+    to_port     = 2049
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 20048
+    to_port     = 20048
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 33904
+    to_port     = 33904
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 111
+    to_port     = 111
+    ip_protocol = "udp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 2049
+    to_port     = 2049 
+    ip_protocol = "udp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 20048
+    to_port     = 20048
+    ip_protocol = "udp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
+    from_port   = 33904 
+    to_port     = 33904
+    ip_protocol = "udp"
+    cidr        = "0.0.0.0/0"
+  }
+}
+
+output "ip_storage_ext" {
+  value = "${openstack_networking_floatingip_v2.storage_ext.address}"
+}
+
+output "ip_storage_int" {
+  value = "${openstack_compute_instance_v2.storage.access_ip_v4}"
+}
+
+output "storage_share" {
+  value = "${local.nfs_share}"
+}
+

--- a/caasp4/terraform-os/terraform.tfvars.skel
+++ b/caasp4/terraform-os/terraform.tfvars.skel
@@ -1,0 +1,99 @@
+# Name of the image to use
+# EXAMPLE:
+# image_name = "SLE-15-SP1-JeOS-GMC"
+# JeOS needs default kernel for the nfs modules
+image_name = "SLE-15-SP1-JeOS-GMC"
+
+# Name of the internal network to be created
+# EXAMPLE:
+# internal_net = "testing"
+internal_net = "#~placeholder_stack~#-net"
+
+# Name of the internal subnet to be created
+# EXAMPLE:
+# internal_subnet = "${var.internal_net}-subnet"
+internal_subnet = "#~placeholder_stack~#-net-subnet"
+
+# Name of the internal router to be created
+# EXAMPLE:
+# internal_router = "${var.internal_net}-router"
+internal_router = "#~placeholder_stack~#-net-router"
+
+# Name of the external network to be used, the one used to allocate floating IPs
+# EXAMPLE:
+# external_net = "floating"
+external_net = "floating"
+
+# Identifier to make all your resources unique and avoid clashes with other users of this terraform project
+stack_name = "#~placeholder_stack~#"
+
+# CIDR of the subnet for the internal network
+# EXAMPLE:
+# subnet_cidr = "172.28.0.0/24"
+subnet_cidr = "172.28.0.0/24"
+
+# Number of master nodes
+masters = 1
+
+# Number of worker nodes
+workers = 3
+
+# Size of the master nodes
+# EXAMPLE:
+# master_size = "m1.medium"
+master_size = "m1.xlarge"
+
+# Size of the worker nodes
+# EXAMPLE:
+# worker_size = "m1.medium"
+worker_size = "m1.xxlarge"
+
+# Attach persistent volumes to workers
+workers_vol_enabled = 0
+
+# Size of the worker volumes in GB
+workers_vol_size = 5
+
+# Name of DNS domain
+# dnsdomain = "my.domain.com"
+dnsdomain = "#~placeholder_stack~#.#~placeholder_magic_dns~#"
+
+# Set DNS Entry (0 is false, 1 is true)
+dnsentry = 0
+
+# define the repositories to use
+# EXAMPLE:
+# repositories = {
+#   repository1 = "http://example.my.repo.com/repository1/"
+#   repository2 = "http://example.my.repo.com/repository2/"
+# }
+repositories = {
+     #~placeholder_caasp_repo~#
+     sle15sp1_pool = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA/standard/"
+     sle15sp1_update = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update/standard/"
+     sle15_pool = "http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/"
+     sle15_update = "http://download.suse.de/ibs/SUSE:/SLE-15:/Update/standard/"
+     suse_ca = "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/"
+}
+
+# Minimum required packages. Do not remove them.
+# Feel free to add more packages
+packages = [
+  "kernel-default",
+  "-kernel-default-base",
+  "ca-certificates-suse",
+  "nfs-client",
+  "#~placeholder_caasp_pattern~#"
+]
+
+# ssh keys to inject into all the nodes
+# EXAMPLE:
+# authorized_keys = [
+#  "ssh-rsa <key-content>"
+# ]
+authorized_keys = [
+"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2G7k0zGAjd+0LzhbPcGLkdJrJ/LbLrFxtXe+LPAkrphizfRxdZpSC7Dvr5Vewrkd/kfYObiDc6v23DHxzcilVC2HGLQUNeUer/YE1mL4lnXC1M3cb4eU+vJ/Gyr9XVOOReDRDBCwouaL7IzgYNCsm0O5v2z/w9ugnRLryUY180/oIGeE/aOI1HRh6YOsIn7R3Rv55y8CYSqsbmlHWiDC6iZICZtvYLYmUmCgPX2Fg2eT+aRbAStUcUERm8h246fs1KxywdHHI/6o3E1NNIPIQ0LdzIn5aWvTCd6D511L4rf/k5zbdw/Gql0AygHBR/wnngB5gSDERLKfigzeIlCKf ./id_shared"
+]
+
+# IMPORTANT: Replace these ntp servers with ones from your infrastructure
+ntp_servers = ["0.novell.pool.ntp.org", "1.novell.pool.ntp.org", "2.novell.pool.ntp.org", "3.novell.pool.ntp.org"]

--- a/scripts/caasp4os_deploy.sh
+++ b/scripts/caasp4os_deploy.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+
+# Deploys Caasp4 cluster on openstack, with an nfs server
+# Requires:
+# - Built skuba docker image
+# - Sourced openrc.sh
+# - Key on the ssh keyring. If not, will put one
+
+set -exo pipefail
+
+. scripts/include/caasp4os.sh
+. scripts/include/skuba.sh
+. scripts/include/common.sh
+. .envrc
+
+set -u
+
+export STACK=${STACK:-"$(whoami)-${CAASP_VER::3}-caasp4-cf-ci"}
+export DEBUG=${DEBUG:-0}
+export DOMAIN=${DOMAIN:-'omg.howdoi.website'}
+
+
+if [[ ! -v OS_PASSWORD ]]; then
+    echo ">>> Missing openstack credentials" && exit 1
+fi
+
+# Add ssh key if not present, needed for terraform
+agent="$(pgrep ssh-agent -u "$USER")"
+if [[ "$agent" == "" ]]; then
+    eval "$(ssh-agent -s)"
+fi
+if ! ssh-add -L | grep -q 'ssh' ; then
+    curl "https://raw.githubusercontent.com/SUSE/skuba/master/ci/infra/id_shared" -o id_rsa \
+        && chmod 0600 id_rsa_shared
+    ssh-add id_rsa_shared
+fi
+
+# Extract upstream caasp terraform files
+docker run \
+       --name skuba-"$CAASP_VER" \
+       --detach \
+       --rm \
+       skuba/"$CAASP_VER" sleep infinity
+docker cp \
+       skuba-"$CAASP_VER":/usr/share/caasp/terraform/openstack/. \
+       deployment
+docker rm -f skuba-"$CAASP_VER"
+
+# Inject our terraform files
+case "$CAASP_VER" in
+    "devel")
+         CAASP_REPO='caasp_40_devel_sle15sp1 = "http://download.suse.de/ibs/Devel:/CaaSP:/4.0/SLE_15_SP1/"'
+         ;;
+    "staging")
+         CAASP_REPO='caasp_40_staging_sle15sp1 = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/staging/"'
+         ;;
+    "product")
+         CAASP_REPO='caasp_40_product_sle15sp1 = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/standard/"'
+         ;;
+    "update")
+         CAASP_REPO='caasp_40_update_sle15sp1 = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40:/Update/standard/"'
+         ;;
+esac
+escapeSubst() {
+    # escape string for usage in a sed substitution expression
+    IFS= read -d '' -r < <(sed -e ':a' -e '$!{N;ba' -e '}' -e 's%[&/\]%\\&%g; s%\n%\\&%g' <<<"$1")
+    printf %s "${REPLY%$'\n'}"
+}
+SSHKEY="$(ssh-add -L)"
+CAASP_PATTERN='patterns-caasp-Node-1.15'
+sed -e "s%#~placeholder_stack~#%$(escapeSubst "$STACK")%g" \
+    -e "s%#~placeholder_magic_dns~#%$(escapeSubst "$DOMAIN")%g" \
+    -e "s%#~placeholder_caasp_repo~#%$(escapeSubst "$CAASP_REPO")%g" \
+    -e "s%#~placeholder_sshkey~#%$(escapeSubst "$SSHKEY")%g" \
+    -e "s%#~placeholder_caasp_pattern~#%$(escapeSubst "$CAASP_PATTERN")%g" \
+    ../caasp4/terraform-os/terraform.tfvars.skel > \
+    deployment/terraform.tfvars
+sed -i '/\"\${openstack_compute_secgroup_v2\.secgroup_worker\.name}\",/a \ \ \ \ "\${openstack_compute_secgroup_v2.secgroup_cap.name}",' \
+    deployment/worker-instance.tf
+cp -r ../caasp4/terraform-os/* deployment/
+
+pushd deployment
+
+# Deploy infra with terraform
+skuba_container terraform init
+skuba_container terraform plan -out my-plan
+skuba_container terraform apply -auto-approve my-plan
+
+# Bootstrap k8s with skuba
+skuba_deploy
+wait
+cp -f ./my-cluster/admin.conf ../kubeconfig
+
+# Disable annoying k8s cluster options
+skuba_updates all disable
+wait
+skuba_reboots disable
+wait
+
+# Enable swapaccount on all k8s nodes
+skuba_run_cmd all "sudo sed -i -r 's|^(GRUB_CMDLINE_LINUX_DEFAULT=)\"(.*.)\"|\1\"\2 cgroup_enable=memory swapaccount=1 \"|' /etc/default/grub"
+wait
+skuba_run_cmd all 'sudo grub2-mkconfig -o /boot/grub2/grub.cfg'
+wait
+skuba_run_cmd all 'sleep 2 && sudo nohup shutdown -r now > /dev/null 2>&1 &'
+wait
+# skuba_wait_ssh all 100
+sleep 100
+
+# Create k8s configmap
+PUBLIC_IP="$(skuba_container terraform output ip_workers | cut -d, -f1 | head -n1)"
+export PUBLIC_IP
+ROOTFS=overlay-xfs
+export ROOTFS
+NFS_SERVER_IP="$(skuba_container terraform output ip_storage_int)"
+export NFS_SERVER_IP
+NFS_PATH="$(skuba_container terraform output storage_share)"
+export NFS_PATH
+
+if ! kubectl get configmap -n kube-system 2>/dev/null | grep -qi cap-values; then
+    kubectl create configmap -n kube-system cap-values \
+            --from-literal=public-ip="${PUBLIC_IP}" \
+            --from-literal=garden-rootfs-driver="${ROOTFS}" \
+            --from-literal=nfs-server-ip="${NFS_SERVER_IP}" \
+            --from-literal=nfs-path="${NFS_PATH}" \
+            --from-literal=platform=caasp4
+fi

--- a/scripts/caasp4os_destroy.sh
+++ b/scripts/caasp4os_destroy.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Destroys an existing Caasp4 cluster on openstack
+#
+# Requirements:
+# - Built skuba docker image
+# - Sourced openrc.sh
+# - Key on the ssh keyring
+
+. scripts/include/caasp4os.sh
+. scripts/include/skuba.sh
+. scripts/include/common.sh
+
+set -exuo pipefail
+
+
+if [ -d ../"$BUILD_DIR" ]; then
+    if [[ ! -v OS_PASSWORD ]]; then
+        echo ">>> Missing openstack credentials" && exit 1
+    fi
+
+    . .envrc
+    if kubectl get storageclass 2>/dev/null | grep -qi persistent; then
+        # destroy storageclass, allowing nfs server to delete the share
+        kubectl delete storageclass persistent
+        wait
+    fi
+
+    pushd deployment
+    # destroy terraform openstack stack
+    skuba_container terraform destroy -auto-approve
+    popd
+
+    popd
+    rm -rf "$BUILD_DIR"
+fi
+

--- a/scripts/caasp_prepare.sh
+++ b/scripts/caasp_prepare.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+
+# Takes a newly deployed Caasp4 cluster, provided by the kubeconfig, and prepares
+# it for CAP
+#
+# Requires:
+# kubectl & helm binaries
+
+. scripts/include/caasp4os.sh
+. scripts/include/common.sh
+
+set -exuo pipefail
+. .envrc
+
+create_rolebinding() {
+    kubectl apply -f - << HEREDOC
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: cluster-admin
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-system:default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kube-system
+HEREDOC
+}
+
+install_helm_and_tiller() {
+    if kubectl get pods --all-namespaces 2>/dev/null | grep -qi tiller; then
+        # Tiller already present
+        helm init --client-only
+    else
+        kubectl create serviceaccount tiller --namespace kube-system
+        helm init --wait
+    fi
+}
+
+create_nfs_storageclass() {
+    # Create nfs storageclass with provided nfs server
+    if ! kubectl get storageclass 2>/dev/null | grep -qi persistent; then
+        NFS_SERVER_IP=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["nfs-server-ip"]')
+        NFS_PATH=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["nfs-path"]')
+        helm install stable/nfs-client-provisioner \
+             --set nfs.server="$NFS_SERVER_IP" \
+             --set nfs.path="$NFS_PATH" \
+             --set storageClass.name=persistent \
+             --set storageClass.reclaimPolicy=Delete \
+             --set storageClass.archiveOnDelete=false
+    fi
+}
+
+create_rolebinding
+install_helm_and_tiller
+create_nfs_storageclass

--- a/scripts/docker_skuba.sh
+++ b/scripts/docker_skuba.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+. scripts/include/caasp4os.sh
+
+if [[ "$(docker images -q skuba/$CAASP_VER 2> /dev/null)" == "" ]]; then
+		make -C "$CF_CI_DIR"/docker/skuba/ "$CAASP_VER"
+fi

--- a/scripts/include/caasp4os.sh
+++ b/scripts/include/caasp4os.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export cluster_name=${CLUSTER_NAME:-"$(whoami)-caasp4"}
+export CAASP_VER=${CAASP_VER:-"product"}

--- a/scripts/include/common.sh
+++ b/scripts/include/common.sh
@@ -6,15 +6,17 @@ if [ -n "$VALUES_OVERRIDE" ] && [ -f "$VALUES_OVERRIDE" ]; then
   OVERRIDE=$(cat $VALUES_OVERRIDE)
 fi
 
-# Forces our build context
-[ -d "build${CLUSTER_NAME}" ] && pushd build${CLUSTER_NAME}
+export cluster_name=${CLUSTER_NAME:-kind}
+export BUILD_DIR=build${cluster_name}
 
+# Forces our build context
+[ -d "$BUILD_DIR" ] && pushd "$BUILD_DIR"
+
+export ROOT_DIR="$(git rev-parse --show-toplevel)"
 export CHART_URL="${CHART_URL:-}"
 export KUBECONFIG=$PWD/kubeconfig
 export SCF_REPO="${SCF_REPO:-https://github.com/SUSE/scf}"
 export SCF_BRANCH="${SCF_BRANCH:-develop}"
-export cluster_name=${CLUSTER_NAME:-kind}
-
 if [ -n "$EKCP_HOST" ]; then
   export container_ip=$(curl -s http://$EKCP_HOST/ | jq .ClusterIPs.${CLUSTER_NAME} -r)
   export DOMAIN="${CLUSTER_NAME}.${container_ip}.${EKCP_DOMAIN}"

--- a/scripts/include/skuba.sh
+++ b/scripts/include/skuba.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+
+# Functions to interact with a container that includes the client caasp4
+# binaries and terraform
+
+SKUBA_CLUSTER_NAME="my-cluster" #default from caasp
+
+_set_env_vars() {
+    JSON=$(skuba_container terraform output -json)
+    export LB=$(echo "$JSON" | jq -r '.ip_load_balancer.value')
+    export MASTERS=$(echo "$JSON" | jq -r '.ip_masters.value[]')
+    export WORKERS=$(echo "$JSON" | jq -r '.ip_workers.value[]')
+    export ALL="$MASTERS $WORKERS"
+}
+
+_define_node_group() {
+    _set_env_vars
+    case "$1" in
+        "all")
+            GROUP="$ALL"
+            ;;
+        "masters")
+            GROUP="$MASTERS"
+            ;;
+        "workers")
+            GROUP="$WORKERS"
+            ;;
+        *)
+            GROUP="$1"
+            ;;
+    esac
+}
+
+
+skuba_container() {
+    # Usage:
+    # skuba_container <commands to run in a punctured container>
+
+    local app_path="$PWD"
+    if [[ "$1" == "$SKUBA_CLUSTER_NAME" ]]; then
+        local app_path="$PWD/$1"
+        shift
+    fi
+    docker run -i --rm \
+    -v "$app_path":/app:rw \
+    -v "$(dirname "$SSH_AUTH_SOCK")":"$(dirname "$SSH_AUTH_SOCK")" \
+    -v "/etc/passwd:/etc/passwd:ro" \
+    --env-file <( env| cut -f1 -d= ) \
+    -e SSH_AUTH_SOCK="$SSH_AUTH_SOCK" \
+    -u "$(id -u)":"$(id -g)" \
+    skuba/$CAASP_VER "$@"
+}
+
+_ssh2() {
+    local host=$1
+    shift
+    ssh -o UserKnownHostsFile=/dev/null \
+        -o StrictHostKeyChecking=no \
+        -F /dev/null \
+        -o LogLevel=ERROR \
+        "sles@$host" "$@"
+}
+
+skuba_wait_ssh() {
+    # Usage:
+    # wait_ssh <target>
+
+    timeout=$2
+    local target="${1:-all}"
+
+    _define_node_group "$target"
+    for n in $GROUP; do
+        secs=0
+        set +e
+        _ssh2 $n exit
+        while test $? -gt 0
+        do
+            if [ $secs -gt $timeout ] ; then
+                echo "Timeout while waiting for $n"
+                exit 2
+            else
+                sleep 5
+                secs=$(( secs + 5 ))
+                _ssh2 $n exit
+            fi
+        done
+        set -e
+    done
+}
+
+skuba_reboots() {
+    # usage:
+    # reboots disable
+
+    local action="${1:-disable}"
+
+    if [[ "$action" == "disable" ]]; then
+        kubectl -n kube-system annotate ds kured weave.works/kured-node-lock='{"nodeid":"manual"}'
+    else
+        kubectl -n kube-system annotate ds kured weave.works/kured-node-lock-
+    fi
+}
+
+skuba_run_cmd() {
+    # Usage:
+    # run_cmd <target> "sudo ..."
+    # run_cmd all "sudo ..."
+    # run_cmd masters "sudo ..."
+
+    local target="${1:-all}"
+    local action="${2:-disable}"
+
+    _define_node_group "$target"
+    CMD="$action"
+    for n in $GROUP; do
+        _ssh2 "$n" "$CMD"
+    done
+}
+
+skuba_use_scp() {
+    # Usage:
+    # use_scp <target> <src_files> <dest_files>
+    # use_scp masters <src_files> <dest_files>
+    # use_scp workers <src_files> <dest_files>
+
+    local target="${1:-all}"
+
+    _define_node_group "$target"
+    SRC="$2"
+    DEST="$3"
+    local options="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -F /dev/null -o LogLevel=ERROR -r"
+
+    for n in $GROUP; do
+        scp "$options" "$SRC" sles@$n:"$DEST"
+    done
+}
+
+skuba_show_images() {
+    kubectl get pods --all-namespaces -o jsonpath="{.items[*].spec.containers[*].image}" | tr -s '[[:space:]]' '\n'
+}
+
+skuba_updates() {
+    # Usage:
+    # updates <target> <action>
+    # updates all disable
+
+    local target="${1:-all}"
+    local action="${2:-disable}"
+
+    _define_node_group "$target"
+    for n in $GROUP; do
+        _ssh2 "$n" "sudo systemctl $action --now skuba-update.timer"
+    done
+}
+
+_init_control_plane() {
+    if ! [[ -d "$SKUBA_CLUSTER_NAME" ]]; then
+        skuba_container skuba cluster init --control-plane "$LB" "$SKUBA_CLUSTER_NAME"
+    fi
+}
+
+_deploy_masters() {
+local i=0
+for n in $1; do
+    local j="$(printf "%03g" $i)"
+    if [[ $i -eq 0 ]]; then
+      skuba_container "$SKUBA_CLUSTER_NAME" skuba node bootstrap --user sles --sudo --target "$n" "master$j" -v "$DEBUG"
+      wait
+    fi
+
+    if [[ $i -ne 0 ]]; then
+      skuba_container "$SKUBA_CLUSTER_NAME" skuba node join --role master --user sles --sudo --target  "$n" "master$j" -v "$DEBUG"
+      wait
+    fi
+    ((++i))
+done
+}
+
+_deploy_workers() {
+    local i=0
+    for n in $1; do
+        local j="$(printf "%03g" $i)"
+        (skuba_container "$SKUBA_CLUSTER_NAME" skuba node join --role worker --user sles --sudo --target  "$n" "worker$j" -v "$DEBUG") &
+        wait
+        ((++i))
+    done
+}
+
+skuba_deploy() {
+    # Usage: deploy
+
+    local KUBECONFIG=""
+    _set_env_vars
+    _init_control_plane
+    pushd $(pwd)/
+    _deploy_masters "$MASTERS"
+    _deploy_workers "$WORKERS"
+    skuba_container $SKUBA_CLUSTER_NAME skuba cluster status
+}
+
+skuba_node_upgrade() {
+    # Usage:
+    #   skuba_node_upgrade <target>
+    #   skuba_node_upgrade all
+    #   skuba_node_upgrade masters
+    #   skuba_node_upgrade workers
+
+    local target="${1:-all}"
+
+     _define_node_group "$target"
+    local i=0
+    for n in $GROUP; do
+        skuba_container "$SKUBA_CLUSTER_NAME" skuba node upgrade \
+                        apply --user sles --sudo --target "$n" -v "$DEBUG"
+    done
+}

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -14,4 +14,11 @@ if [ -z "$EKCP_HOST" ]; then
     mv kind-linux-amd64 kind
     chmod +x kind
 fi
+
+cat <<HEREDOC > .envrc
+export KUBECONFIG=$(pwd)/kubeconfig
+export HELM_HOME=$(pwd)/.helm
+export CF_HOME=$(pwd)/.cf
+HEREDOC
+
 popd

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -x
 
-mkdir build${CLUSTER_NAME}
+# duplicated in s/include/common.sh, needed for bootstrapping:
+export cluster_name=${CLUSTER_NAME:-kind}
+export BUILD_DIR=build${cluster_name}
+
+mkdir "$BUILD_DIR"
 
 . scripts/include/common.sh
 


### PR DESCRIPTION
This PR adds scripts and content to deploy caasp4 on openstack.
See `make all-caasp4os`.

It creates a docker image with the caasp4 product, spawns infra by terraform,
bootstraps the cluster with skuba, and configures and prepares cluster for cap.

Currently it fails on install_scf.sh, since the scripts/include/common.sh containerid/ip are not correctly set up.

For moving forward we would need to refactor the rules into steps that are k8s platform agnostic.
This can be achieved by saving the k8s external info (external ip, nfs server, etc) on a configmap on the cluster, see example at the end of `scripts/caasp4_deploy.sh`, and thinning `scripts/include/common.sh` and creating `scripts/include/<platform>.sh`

This would mean a change of the structure of the repo.