### PR TITLE
Defer DEFAULT_STACK assignment until gen_scf_config.sh and cats.sh

### DIFF
--- a/scripts/cats.sh
+++ b/scripts/cats.sh
@@ -4,6 +4,10 @@ set -ex
 
 . scripts/include/common.sh
 
+if [ -z "${DEFAULT_STACK}" ]; then
+    export DEFAULT_STACK=$(helm inspect helm/cf/ | grep DEFAULT_STACK | sed  's~DEFAULT_STACK:~~g' | sed 's~"~~g' | sed 's~\s~~g')
+fi
+
 [ ! -d "cf-acceptance-tests" ] && git clone https://github.com/cloudfoundry/cf-acceptance-tests
 
 pushd cf-acceptance-tests

--- a/scripts/gen_scf_config.sh
+++ b/scripts/gen_scf_config.sh
@@ -3,6 +3,10 @@ set -ex
 
 . scripts/include/common.sh
 
+if [ -z "${DEFAULT_STACK}" ]; then
+    export DEFAULT_STACK=$(helm inspect helm/cf/ | grep DEFAULT_STACK | sed  's~DEFAULT_STACK:~~g' | sed 's~"~~g' | sed 's~\s~~g')
+fi
+
 VALUES=
 if [ "$ENABLE_EIRINI" = true ] ; then
   AUTH="rbac"

--- a/scripts/include/common.sh
+++ b/scripts/include/common.sh
@@ -43,8 +43,3 @@ export CLUSTER_PASSWORD="${CLUSTER_PASSWORD:-password}"
 export ENABLE_EIRINI="${ENABLE_EIRINI:-true}"
 export EMBEDDED_UAA="${EMBEDDED_UAA:-false}"
 export KIND_APIVERSION="${KIND_APIVERSION:-kind.sigs.k8s.io/v1alpha2}"
-if [ -z "${DEFAULT_STACK}" ]; then
-  if [ -d "helm/cf" ]; then
-    export DEFAULT_STACK=$(helm inspect helm/cf/ | grep DEFAULT_STACK | sed  's~DEFAULT_STACK:~~g' | sed 's~"~~g' | sed 's~\s~~g')
-  fi
-fi


### PR DESCRIPTION
If not, for the first time, it would fail as s/include/common.sh gets called
everywhere and we don't have helm set up inside of the build folder yet.