### PR TITLE
Typos Fixed

### DIFF
--- a/scripts/kind_tools.sh
+++ b/scripts/kind_tools.sh
@@ -5,8 +5,6 @@ set -x
 export CLUSTER_NAME=${CLUSTER_NAME:-kind}
 export BUILD_DIR=build${CLUSTER_NAME}
 
-mkdir "$BUILD_DIR"
-
 . scripts/include/common.sh
 
 if [[ "$OSTYPE" == "darwin"* ]]; then 

--- a/scripts/kind_tools.sh
+++ b/scripts/kind_tools.sh
@@ -15,7 +15,7 @@ fi
 
 if [ -z "$EKCP_HOST" ]; then
     wget https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/${KIND_OS_TYPE}
-    mv kind-linux-amd64 kind
+    mv ${KIND_OS_TYPE} kind
     chmod +x kind
 fi
 


### PR DESCRIPTION
1. the command _mv_ was using the _linux_ hardcoded name of **kind**, which in case the downloaded file was for another OS, like _darwin_ the command would fail. The fix uses the **KIND_OS_TYPE** variable that establishes the kind file to download based on host OS.

2. the **BUILD_DIR** was being created by the _buildir_ script and so it was duplicated in here.